### PR TITLE
Fix svelte/internal import

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1,5 +1,4 @@
 <script>
-  import { loop_guard, update_await_block_branch } from "svelte/internal";
   import IntersectionObserver from "svelte-intersection-observer";
 
   import Block from "./lib/Block.svelte"


### PR DESCRIPTION
## Summary
- drop obsolete `svelte/internal` import from `App.svelte`

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68452bc970cc832ab1197e209cb216ad