### PR TITLE
Fix banner clipping on wide screens

### DIFF
--- a/src/assets/app.scss
+++ b/src/assets/app.scss
@@ -57,6 +57,8 @@
   
   .banner {
     position:fixed;
+    left: 0;
+    right: 0;
     display: block;
     backdrop-filter: blur(12px);
     -webkit-backdrop-filter: blur(12px);


### PR DESCRIPTION
## Summary
- ensure the fixed banner spans the full viewport width on landscape displays by anchoring it to both sides of the screen

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e0eaeb86d8832aadb36e35413dcd73